### PR TITLE
Sample tweaks

### DIFF
--- a/APPLICATION_DEVELOPMENT.md
+++ b/APPLICATION_DEVELOPMENT.md
@@ -22,7 +22,7 @@ Edgent SDK/runtime jars and package your application
 artifacts for deploying to an edge device or gateway for execution.
 
 The Edgent SDK/runtime jars are published to the 
-[ASF Nexus Repository](https://repository.apache.org/content/repositories/releases/)
+[ASF Nexus Releases Repository](https://repository.apache.org/content/repositories/releases/)
 and the Maven Central Repository.
 Alternatively, you can build the Edgent SDK yourself from a source release
 and the resulting jars will be added to your local maven repository.
@@ -37,7 +37,9 @@ The maven artifact groupIds for the Edgent jars are:
 Note, the Java package names for Edgent components do not incorporate
 the platform kind; the package names are the same regardless of the platform.
 
-See `JAVA_SUPPORT.md` for more information on artifact coordinates, etc.
+See the release's `JAVA_SUPPORT` information in [downloads](https://http://edgent.incubator.apache.org/docs/downloads)
+for more information on artifact coordinates, etc.
+
 
 ## Writing Your Application
 
@@ -89,6 +91,11 @@ the deployment of application and Edgent jars to edge devices is left to
 others (as an example, the IBM Watson IoT Platform has device APIs to
 support "firmware" download/update).
 
+To deploy an Edgent application to a device like a Raspberry Pi, 
+you could just FTP the application to the device and modify the
+device to start the application upon startup or on command.
+Also see the `cron` folder in the Edgent samples.
+
 To run your Edgent application on an edge device, your application
 jar(s) need to be on the device.  Additionally, the application's 
 dependent Edgent jars (and their transitive dependencies) need to
@@ -98,7 +105,7 @@ maven central.
 
 Here are three options for dealing with this.
 
-### Create an uber-jar for your application
+### Option 1: Create an uber-jar for your application
 
 The uber jar is a standalone entity containing
 everything that's needed to run your application.
@@ -112,7 +119,10 @@ the Edgent samples poms contain configuration information
 that generates an uber jar in addition to the standard
 application jar.  Eclipse can also export an uber jar.
 
-### Separately manage the application and Edgent jars
+You run your application like:
+    `java -cp <path-to-uber-jar> <full-classname-of-main-class>`
+
+### Option 2: Separately manage the application and Edgent jars
 
 Copy the application's jars to the device.
 Get a copy of the Edgent jars and their dependencies
@@ -127,7 +137,7 @@ are only released to maven central.
 See [samples/get-edgent-jars-project](get-edgent-jars-project/README.md)
 for a tool to get a copy of the Edgent jars.
 
-### Create an application package bundle
+### Option 3: Create an application package bundle
 
 The bundle is a standalone entity containing
 everything that's needed to run your application.
@@ -136,8 +146,8 @@ The bundle is copied to the device and unpacked.
 A run script forms the appropriate `CLASSPATH`
 to the package's jars and starts the application.
 
-The supplied `package-app.sh` script creates an
-application bundle.
+The `package-app.sh` script included with the
+Edgent samples creates an application bundle.
 
 The application bundle contains the application's jar,
 the application's dependent Edgent jars (as specified in

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,50 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+This note is for the development and maintenance of the samples.
+See [README.md](README.md) for using the samples.
+
+At this time an ASF release is not created for the samples - 
+neither a source release bundle nor binary sample artifacts are
+released.  The expectation is that users will get the samples
+from this github repository.
+
+Generally, the desire is to have the samples build against the
+latest released version of the runtime in Maven Central.
+
+Hence when a new Edgent runtime is released, the samples build tooling
+should be updated to reference the new Edgent release.  
+E.g., when Edgent 1.3.0 is released:
+
+```sh
+    ./update-samples-version.sh --edgent-version 1.3.0
+```
+
+Review the changes and stage/commit the updated files.
+
+
+Since we're not formally releasing the samples, it's currently
+unclear when we'll decide to change the sample artifact version ids.
+We may try to track maintain tracking the Edgent runtime's version.
+Here's the easiest way to change the sample artifact version ids
+when a decision is made to change them:
+
+```sh
+    ./update-samples-version.sh --samples-version 1.3.0-SNAPSHOT
+```
+
+Review the changes and stage/commit the updated files.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@
 
 # Quickstart
 
+If you haven't already done so, download the samples from github:
+```sh
+git clone https://github.com/apache/incubator-edgent-samples
+cd incubator-edgent-samples
+git checkout develop
+```
+
 You must have Java 8 installed on your system. Maven will be automatically
 downloaded and installed by the maven wrapper `mvnw`.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ which is not supported on the Android platform.
 
 Build the samples
 ```sh
-./mvnw clean package  # -Pplatform-java7 as needed
+./mvnw clean package  # -Pplatform-java7 and/or -Dedgent.runtime.version=<the-version> as needed
 ```
 
 A standard jar and uber jar are created for each sample category

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.edgent</groupId>
     <artifactId>edgent-samples</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>edgent-samples-apps</artifactId>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.edgent</groupId>
     <artifactId>edgent-samples</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>edgent-samples-connectors</artifactId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.edgent</groupId>
     <artifactId>edgent-samples</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>edgent-samples-console</artifactId>

--- a/get-edgent-jars-project/pom.xml.template
+++ b/get-edgent-jars-project/pom.xml.template
@@ -30,7 +30,7 @@
 
   <groupId>org.apache.edgent</groupId>
   <artifactId>get-edgent-jars-project</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
 
   <name>Apache Edgent get-edgent-jars-project ${samples.projname.platform}</name>
 

--- a/get-edgent-jars-project/pom.xml.template
+++ b/get-edgent-jars-project/pom.xml.template
@@ -22,11 +22,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <!-- standalone project -->
-  <!--parent>
-    <groupId>org.apache.edgent</groupId>
-    <artifactId>edgent-parent</artifactId>
-    <version>1.2.0</version>
-  </parent-->
 
   <groupId>org.apache.edgent</groupId>
   <artifactId>get-edgent-jars-project</artifactId>

--- a/get-edgent-jars-project/pom.xml.template
+++ b/get-edgent-jars-project/pom.xml.template
@@ -39,11 +39,8 @@
     <edgent.platform>java8</edgent.platform> <!-- tweaked by -Pplatform-* -->    
     <edgent.groupId.platform/> <!-- tweaked by -Pplatform-* -->    
     <edgent.base.groupId>org.apache.edgent${edgent.groupId.platform}</edgent.base.groupId>
-    <!--  at least for now, the samples version is lockstep with the core
-          so default to using the same core as the this project.
-          get-edgent-jars.sh overrides via -Dedgent.runtime.version=...
-    -->
-    <edgent.runtime.version>${project.version}</edgent.runtime.version>
+    <!-- get-edgent-jars.sh overrides via -Dedgent.runtime.version=... -->
+    <edgent.runtime.version>1.2.0</edgent.runtime.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,8 @@
     <samples.projname.platform>(Java 8)</samples.projname.platform>  <!--  tweaked by -Pplatform-* -->
     <edgent.runtime.platform/> <!-- set by -Pplatform-* -->    
     <edgent.runtime.groupId>org.apache.edgent${edgent.runtime.platform}</edgent.runtime.groupId>
-    <!--  at least for now, the samples version is lockstep with the core -->
     <!-- override via 'mvn ... -Dedgent.runtime.version=<the-version>' -->
-    <edgent.runtime.version>${project.version}</edgent.runtime.version>
+    <edgent.runtime.version>1.2.0</edgent.runtime.version>
 
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.apache.edgent</groupId>
   <artifactId>edgent-samples</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Edgent Samples ${samples.projname.platform}:</name>
@@ -39,6 +39,7 @@
     <edgent.runtime.platform/> <!-- set by -Pplatform-* -->    
     <edgent.runtime.groupId>org.apache.edgent${edgent.runtime.platform}</edgent.runtime.groupId>
     <!--  at least for now, the samples version is lockstep with the core -->
+    <!-- override via 'mvn ... -Dedgent.runtime.version=<the-version>' -->
     <edgent.runtime.version>${project.version}</edgent.runtime.version>
 
     <java.version>1.8</java.version>

--- a/scenarios/pom.xml
+++ b/scenarios/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.edgent</groupId>
     <artifactId>edgent-samples</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>edgent-samples-scenarios</artifactId>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <edgent.runtime.platform/>   <!-- set by -Pplatform-* -->
     <edgent.runtime.groupId>org.apache.edgent${edgent.runtime.platform}</edgent.runtime.groupId>
-    <edgent.runtime.version>1.3.0-SNAPSHOT</edgent.runtime.version>
+    <edgent.runtime.version>1.2.0-SNAPSHOT</edgent.runtime.version>
 
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <edgent.runtime.platform/>   <!-- set by -Pplatform-* -->
     <edgent.runtime.groupId>org.apache.edgent${edgent.runtime.platform}</edgent.runtime.groupId>
-    <edgent.runtime.version>1.2.0-SNAPSHOT</edgent.runtime.version>
+    <edgent.runtime.version>1.2.0</edgent.runtime.version>
 
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/topology/pom.xml
+++ b/topology/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.edgent</groupId>
     <artifactId>edgent-samples</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>edgent-samples-topology</artifactId>

--- a/topology/src/main/java/org/apache/edgent/samples/topology/TempSensor.java
+++ b/topology/src/main/java/org/apache/edgent/samples/topology/TempSensor.java
@@ -27,6 +27,7 @@ import org.apache.edgent.function.Supplier;
  * Every time get() is called, TempSensor generates a temperature reading.
  */
 public class TempSensor implements Supplier<Double> {
+    private static final long serialVersionUID = 1L;
     double currentTemp = 65.0;
     Random rand;
 

--- a/update-samples-version.sh
+++ b/update-samples-version.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+################################################################################
+##
+##  Licensed to the Apache Software Foundation (ASF) under one or more
+##  contributor license agreements.  See the NOTICE file distributed with
+##  this work for additional information regarding copyright ownership.
+##  The ASF licenses this file to You under the Apache License, Version 2.0
+##  (the "License"); you may not use this file except in compliance with
+##  the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+################################################################################
+
+set -e
+
+# Change the version of the edgent runtime that the tooling uses
+# and/or change the version of the samples artifacts
+#
+# Generally, by default build against the (latest) edgent runtime version
+# (e.g., "1.2.0").
+# Generally, if/when it's decided to update the sample artifact versions
+# they should remain a -SNAPSHOT version.
+
+USAGE="usage: `basename $0` [--edgent-version <version>] [--samples-version <version>]"
+
+EDGENT_VER=
+if [ "${1}" = "--edgent-version" -a $# -gt 1 ] ; then
+  EDGENT_VER=$2; shift; shift
+fi
+
+SAMPLES_VER=
+if [ "${1}" = "--samples-version" -a $# -gt 1 ] ; then
+  SAMPLES_VER=$2; shift; shift
+fi
+
+if [ "${EDGENT_VER}" = "" -a "${SAMPLES_VER}" = "" ] ; then
+  echo ${USAGE}
+  exit 1;
+fi
+
+if [ $# -gt 0 ] ; then
+  echo ${USAGE}
+  exit 1;
+fi
+
+# yeah, this should be some xslt processing
+
+# update the edgent.runtime.version property
+if [ "${EDGENT_VER}" != "" ] ; then
+    echo updating the edgent.runtime.version property ...
+    POMS=`find . -name pom.xml | grep -v target`
+    POMS="${POMS} `find . -name pom.xml.template | grep -v target`"
+    for POM in ${POMS}; do
+      if [ `grep -s '<edgent.runtime.version>' ${POM}` ] ; then
+        echo updating ${POM} for edgent.runtime.version ... 
+        sed -i -e "s,<edgent.runtime.version>.*</edgent.runtime.version>,<edgent.runtime.version>${EDGENT_VER}</edgent.runtime.version>," ${POM}
+        mv ${POM}-e ${POM}~
+      fi
+    done 
+fi
+
+# update the sample artifact ids
+if [ "${SAMPLES_VER}" != "" ] ; then
+    echo updating the sample artifact versions ...
+
+    # update get-edgent-jars/pom.xml.template's artifact version
+    POM=./get-edgent-jars-project/pom.xml.template
+    echo updating ${POM} ...
+    cp ${POM} ${POM}~ 
+    awk "!done && /<version>/ { print \"  <version>${SAMPLES_VER}</version>\"; done=1; next;}; \
+         1;" < ${POM}~ >${POM}
+
+    # update the other poms
+    # skip template/pom.xml as it's artifact version never changes
+    POMS=`find . -name pom.xml | grep -v template | grep -v target`
+    for POM in ${POMS} ; do
+      echo updating ${POM} ...
+      cp ${POM} ${POM}~
+      if [ "${POM}" = "./pom.xml" ] ; then
+        # change the artifact's <version> (after the <parent> spec)
+        awk "\
+           !firstMatch && /<\/parent>/ { firstMatch=1; print \$0; next; }; \
+           firstMatch && !done && /<version>/ { print \"  <version>${SAMPLES_VER}</version>\"; done=1; next;}; \
+           1;" < ${POM}~ >${POM}
+      else
+        # change the <parent> spec's <version> (the child sample pom's artifact implicitly inherits it)
+        awk "\
+           !firstMatch && /<parent>/ { firstMatch=1; print \$0; next; }; \
+           firstMatch && !done && /<version>/ { print \"    <version>${SAMPLES_VER}</version>\"; done=1; next;}; \
+           1;" < ${POM}~ >${POM}
+      fi
+    done
+fi

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.edgent</groupId>
     <artifactId>edgent-samples</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>edgent-samples-utils</artifactId>


### PR DESCRIPTION
- update README.md with download info and other changes from the website version
- add DEVELOPMENT.md
- add update-samples-version.sh for updating tooling (poms) for either the edgent runtime version or the version of the (unreleased) sample artifacts
- set the samples version id to 1.2.0-SHAPSHOT (match develop on the Edgent runtime)
- set the samples to build against the (to become first/latest) Edgent runtime release: 1.2.0
- fix warning in sample TempSensor.java